### PR TITLE
Refactor image distribution methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,74 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+.python-version
+
+# virtualenvs
+.venv
+venv
+**/venv3/
+
+# Custom
 *.log
 Untitled*.ipynb
-.python-version
-.cache
+
 **/CC-Ubuntu/
-**/venv3/
 **/upper-constraints.txt
 **/*.egg-info/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests/unit",
+        "-p",
+        "test_*.py"
+    ]
+}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+black
+isort
+flake8
+responses
+oslotest

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,9 @@ croniter
 paramiko
 requests
 ulid
+openstacksdk
 
-# test
+# functional tests of images
 pytest
 pytest-timeout
 spur

--- a/site_tools/deployer2.py
+++ b/site_tools/deployer2.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""
+Download image from the centralized object store and deploy to the site.
+"""
+import argparse
+import logging
+
+from utils.common import load_supported_images_from_config
+from utils import swift as chi_img_swift, glance as chi_img_glance
+
+import openstack
+
+LOG = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # parser.add_argument(
+    #     "--site-yaml",
+    #     type=str,
+    #     required=True,
+    #     help="A yaml file with site credentials.",
+    # )
+    parser.add_argument(
+        "--supports-yaml",
+        type=str,
+        default="/etc/chameleon_image_tools/supports.yaml",
+        help="A yaml file with supported images.",
+    )
+    parser.add_argument(
+        "--latest",
+        type=str,
+        nargs=3,
+        metavar=("distro", "release", "variant"),
+        help="Publish latest tested image given 3 args:<distro> <release> <variant>",
+    )
+    parser.add_argument(
+        "--ipa",
+        type=str,
+        default="na",
+        choices=["initramfs", "kernel"],
+        help='IPA metadata; if not IPA image, set to "na"; default "na"',
+    )
+    parser.add_argument("--image", type=str, help="Image id to publish")
+
+    args = parser.parse_args()
+
+    # configuration for each image type, including production name and suffix
+    configured_image_types = load_supported_images_from_config(args.supports_yaml)
+    print(configured_image_types)
+
+    # initiate connection to swift for reuse, as well as applying config for naming
+    # swift_img_conn = chi_img_swift.swift_manager(
+    #     supported_images=configured_image_types
+    # )
+
+    # available_supported_images = [
+    #     i
+    #     for i in swift_img_conn.list_images()
+    #     if i.image_type in configured_image_types
+    # ]
+
+    # Initialize connection
+    conn = openstack.connect(cloud="uc_dev_admin")
+
+    # for each available, supported image, check if it's in glance.
+    for i in conn.image.images():
+        tmp_img = chi_img_glance.chi_glance_image(i)
+        print(tmp_img)
+
+
+if __name__ == "__main__":
+    main()

--- a/site_tools/deployer2.py
+++ b/site_tools/deployer2.py
@@ -55,7 +55,6 @@ def main():
     glance_image_set = set(glance_image_generator)
 
     # list images present in swift, but not in glance
-    # TODO: not correctly removing images found in glance
     unsynced_images = swift_image_set.difference(glance_image_set)
 
     def _isLatest(img, img_set):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -103,6 +103,7 @@ class TestSupportsYaml(base.TestCase):
             self.assertIsNotNone(i.distro_family)
             self.assertIsNotNone(i.distro_release)
             self.assertIsNotNone(i.image_variant)
+            self.assertIsNotNone(i.production_name_base)
 
             prod_name = i.production_name()
             production_names.append(prod_name)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,0 +1,73 @@
+import uuid
+from openstack.tests import base, fakes
+from utils import common
+
+
+fake_distro_family = "ubuntu"
+fake_distro_release = "20.04"
+
+fake_production_image_name_base = "CC-Ubuntu-20.04"
+fake_production_image_name_gpu = "CC-Ubuntu-20.04-CUDA"
+fake_production_image_name_fpga = "CC-Ubuntu-20.04-FPGA"
+fake_production_image_name_arm64 = "CC-Ubuntu-20.04-ARM64"
+
+# fake_glance_image = fakes.make_fake_image(image_id=fake_image_uuid)
+fake_image_uuid = uuid.uuid4().hex
+fake_image_size_bytes = "204800000"
+fake_build_date = "2022-12-06"
+fake_archival_image_name = "CC-Ubuntu-20.04-2022-12-06"
+
+
+class TestChiImageType(base.TestCase):
+    def setUp(self):
+        self.TIMEOUT_SCALING_FACTOR = 10000
+        return super().setUp()
+
+    def _get_image_variant(self, variant, suffix):
+        return common.chi_image_type(
+            family=fake_distro_family,
+            release=fake_distro_release,
+            variant=variant,
+            prod_name=fake_production_image_name_base,
+            suffix=suffix,
+        )
+
+    def test_production_name_base(self):
+        img = self._get_image_variant(variant=None, suffix=None)
+        assert img.production_name() == fake_production_image_name_base
+
+    def test_production_name_gpu(self):
+        img = self._get_image_variant(variant="gpu", suffix="CUDA")
+        assert img.production_name() == fake_production_image_name_gpu
+
+    def test_production_name_fpga(self):
+        img = self._get_image_variant(variant="fpga", suffix="FPGA")
+        assert img.production_name() == fake_production_image_name_fpga
+
+    def test_production_name_arm64(self):
+        img = self._get_image_variant(variant="arm65", suffix="ARM64")
+        assert img.production_name() == fake_production_image_name_arm64
+
+
+class TestChiImageBase(base.TestCase):
+    def setUp(self):
+        self.TIMEOUT_SCALING_FACTOR = 10000
+        self.img_type = common.chi_image_type(
+            family=fake_distro_family,
+            release=fake_distro_release,
+            variant=None,
+            prod_name=fake_production_image_name_base,
+            suffix=None,
+        )
+        return super().setUp()
+
+    def test_archival_name(self):
+        img_instance = common.chi_image(
+            self.img_type,
+            uuid=fake_image_uuid,
+            build_date=fake_build_date,
+            size_bytes=fake_image_size_bytes,
+            checksum_md5=None,
+        )
+        print(img_instance.archival_name())
+        assert img_instance.archival_name() == fake_archival_image_name

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -17,6 +17,24 @@ fake_image_revision = "20230217"
 fake_build_timestamp = "1665164598.226599"
 fake_archival_image_name = "CC-Ubuntu-20.04-20230217-1665164598.226599"
 
+# The default supports.yaml should contain configurations for these images
+supported_image_names = [
+    "CC-CentOS7",
+    "CC-CentOS7-CUDA",
+    "CC-CentOS7-FPGA",
+    "CC-CentOS8-stream",
+    "CC-CentOS8-stream-CUDA",
+    "CC-Ubuntu18.04",
+    "CC-Ubuntu18.04-CUDA",
+    "CC-Ubuntu20.04",
+    "CC-Ubuntu20.04-CUDA",
+    "CC-Ubuntu20.04-ARM64",
+    "CC-Ubuntu22.04",
+    "CC-Ubuntu22.04-CUDA",
+    "CC-Ubuntu22.04-ARM64",
+    "CC-IPA-Debian11-AMD64",
+]
+
 
 class TestChiImageType(base.TestCase):
     def setUp(self):
@@ -71,3 +89,27 @@ class TestChiImageBase(base.TestCase):
             checksum_md5=None,
         )
         assert img_instance.archival_name() == fake_archival_image_name
+
+
+class TestSupportsYaml(base.TestCase):
+    def setUp(self):
+        self.TIMEOUT_SCALING_FACTOR = 10000
+        return super().setUp()
+
+    def test_config_load(self):
+        images = common.load_supported_images_from_config("supports.yaml")
+        production_names = []
+        for i in images:
+            self.assertIsNotNone(i.distro_family)
+            self.assertIsNotNone(i.distro_release)
+            self.assertIsNotNone(i.image_variant)
+
+            prod_name = i.production_name()
+            production_names.append(prod_name)
+
+            # check that each config item is a known variant
+            self.assertIn(prod_name, supported_image_names)
+
+        for sn in supported_image_names:
+            # reverse check, ensure known variant is present in the config file
+            self.assertIn(sn, production_names)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -43,9 +43,9 @@ class TestChiImageType(base.TestCase):
 
     def _get_image_variant(self, variant, suffix):
         return common.chi_image_type(
-            family=fake_distro_family,
-            release=fake_distro_release,
-            variant=variant,
+            distro_family=fake_distro_family,
+            distro_release=fake_distro_release,
+            image_variant=variant,
             prod_name=fake_production_image_name_base,
             suffix=suffix,
         )
@@ -71,16 +71,16 @@ class TestChiImageBase(base.TestCase):
     def setUp(self):
         self.TIMEOUT_SCALING_FACTOR = 10000
         self.img_type = common.chi_image_type(
-            family=fake_distro_family,
-            release=fake_distro_release,
-            variant=None,
+            distro_family=fake_distro_family,
+            distro_release=fake_distro_release,
+            image_variant=None,
             prod_name=fake_production_image_name_base,
             suffix=None,
         )
         return super().setUp()
 
     def test_archival_name(self):
-        img_instance = common.chi_image(
+        img_instance = common.chi_image_instance(
             self.img_type,
             uuid=fake_image_uuid,
             revision=fake_image_revision,

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -11,11 +11,11 @@ fake_production_image_name_gpu = "CC-Ubuntu-20.04-CUDA"
 fake_production_image_name_fpga = "CC-Ubuntu-20.04-FPGA"
 fake_production_image_name_arm64 = "CC-Ubuntu-20.04-ARM64"
 
-# fake_glance_image = fakes.make_fake_image(image_id=fake_image_uuid)
 fake_image_uuid = uuid.uuid4().hex
 fake_image_size_bytes = "204800000"
-fake_build_date = "2022-12-06"
-fake_archival_image_name = "CC-Ubuntu-20.04-2022-12-06"
+fake_image_revision = "20230217"
+fake_build_timestamp = "1665164598.226599"
+fake_archival_image_name = "CC-Ubuntu-20.04-20230217-1665164598.226599"
 
 
 class TestChiImageType(base.TestCase):
@@ -65,9 +65,9 @@ class TestChiImageBase(base.TestCase):
         img_instance = common.chi_image(
             self.img_type,
             uuid=fake_image_uuid,
-            build_date=fake_build_date,
+            revision=fake_image_revision,
+            build_timestamp=fake_build_timestamp,
             size_bytes=fake_image_size_bytes,
             checksum_md5=None,
         )
-        print(img_instance.archival_name())
         assert img_instance.archival_name() == fake_archival_image_name

--- a/tests/unit/test_glance.py
+++ b/tests/unit/test_glance.py
@@ -1,0 +1,24 @@
+import uuid
+from openstack.tests import base, fakes
+from utils import common
+
+fake_image_uuid = uuid.uuid4().hex
+fake_glance_image = fakes.make_fake_image(image_id=fake_image_uuid)
+
+
+class TestGlance(base.TestCase):
+    def setUp(self):
+        self.TIMEOUT_SCALING_FACTOR = 10000
+        return super().setUp()
+
+    def test_image_list(self):
+        raise NotImplemented
+
+    def test_upload_new_image(self):
+        raise NotImplemented
+
+    def test_archive_image(self):
+        raise NotImplemented
+
+    def test_safe_promote_image(self):
+        raise NotImplemented

--- a/tests/unit/test_swift.py
+++ b/tests/unit/test_swift.py
@@ -1,4 +1,4 @@
-from openstack.tests import base, fakes
+from openstack.tests import base
 from utils import swift
 import responses
 import hashlib
@@ -6,22 +6,6 @@ import uuid
 
 
 BUCKET_URL = "https://chi.tacc.chameleoncloud.org:7480/swift/v1/AUTH_570aad8999f7499db99eae22fe9b29bb/chameleon-images"
-
-
-archived_image_name = "CC-Ubuntu-20.04-2022-12-06"
-current_image_name = "CC-Ubuntu-20.04"
-
-
-# Create fakes for preexisting image
-old_image_uuid = uuid.uuid4().hex
-old_image = fakes.make_fake_image(image_id=old_image_uuid)
-
-
-# Create fakes for newly available image
-new_image_uuid = uuid.uuid4().hex
-new_image = fakes.make_fake_image(
-    image_id=new_image_uuid, image_name=current_image_name
-)
 
 swift_image_uuid = uuid.uuid4()
 swift_image_uuid_string = str(swift_image_uuid)

--- a/tests/unit/test_swift.py
+++ b/tests/unit/test_swift.py
@@ -1,0 +1,86 @@
+from openstack.tests import base, fakes
+from chi_image_tools import swift
+import responses
+import hashlib
+import uuid
+
+
+BUCKET_URL = "https://chi.tacc.chameleoncloud.org:7480/swift/v1/AUTH_570aad8999f7499db99eae22fe9b29bb/chameleon-images"
+
+
+archived_image_name = "CC-Ubuntu-20.04-2022-12-06"
+current_image_name = "CC-Ubuntu-20.04"
+
+
+# Create fakes for preexisting image
+old_image_uuid = uuid.uuid4().hex
+old_image = fakes.make_fake_image(image_id=old_image_uuid)
+
+
+# Create fakes for newly available image
+new_image_uuid = uuid.uuid4().hex
+new_image = fakes.make_fake_image(
+    image_id=new_image_uuid, image_name=current_image_name
+)
+
+swift_image_uuid = uuid.uuid4()
+swift_image_uuid_string = str(swift_image_uuid)
+swift_image_suffix = [str(s).zfill(6) for s in range(1, 7)]
+swift_image_part_names = [f"{swift_image_uuid_string}-{s}" for s in swift_image_suffix]
+swift_part_bytes = 204800000
+swift_last_modified = "2022-04-15T20:13:12.953Z"
+
+
+def _swift_item_json(name, item_bytes, last_modified):
+    enc_name = name.encode()
+    hash_name = hashlib.md5(enc_name).hexdigest()
+
+    return {
+        "name": name,
+        "hash": hash_name,
+        "bytes": item_bytes,
+        "last_modified": last_modified,
+    }
+
+
+list_response_json = []
+list_response_json.append(
+    _swift_item_json(swift_image_uuid_string, 0, swift_last_modified)
+)
+
+
+for name in swift_image_part_names:
+    list_response_json.append(
+        _swift_item_json(name, swift_part_bytes, swift_last_modified)
+    )
+
+
+class TestSwift(base.TestCase):
+    def setUp(self):
+        self.TIMEOUT_SCALING_FACTOR = 10000
+        return super().setUp()
+
+    @responses.activate
+    def test_list_swift_images(self):
+        """
+        We should observe one GET call to get the list of items in the bucket
+        And a HEAD call for each image UUID in the above returned list
+
+        """
+        list_rsp_fake = responses.Response(
+            method="GET",
+            url=BUCKET_URL,
+            status=200,
+            json=list_response_json,
+        )
+        responses.add(list_rsp_fake)
+
+        image_head_fake = responses.head(url=f"{BUCKET_URL}/{swift_image_uuid_string}")
+
+        swift_mgr = swift.swift_manager()
+        # uses yield, we must use the result to ensure it's called at least once
+        item_gen = swift_mgr.list_images()
+        images = list(item_gen)
+
+        assert list_rsp_fake.call_count == 1
+        assert image_head_fake.call_count == 1

--- a/tests/unit/test_swift.py
+++ b/tests/unit/test_swift.py
@@ -1,5 +1,5 @@
 from openstack.tests import base, fakes
-from chi_image_tools import swift
+from utils import swift
 import responses
 import hashlib
 import uuid

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,6 +1,7 @@
 import yaml
 
 from oslo_log import log as logging
+from utils import constants
 
 LOG = logging.getLogger(__name__)
 
@@ -155,3 +156,23 @@ def load_supported_images_from_config(config_file_path):
                     supported_images.add(image)
 
     return supported_images
+
+
+def map_attribute_value(field: constants.ImageField, s_type, s_obj, d_type, d_obj):
+    def _resolve(obj, spec):
+        """Attempt to get value from class or dict"""
+        try:
+            # if dict-like
+            value = obj[spec]
+        except (TypeError, KeyError):
+            # if class-like
+            value = getattr(obj, spec, None)
+        return value
+
+    # programatically fetch key names from a namedtuple
+    # and map value between source and dest dictionary
+    source_attr_key = getattr(field, s_type)
+    dest_attr_key = getattr(field, d_type)
+    if source_attr_key and dest_attr_key:
+        source_attr_value = _resolve(s_obj, source_attr_key)
+        d_obj[dest_attr_key] = source_attr_value

--- a/utils/common.py
+++ b/utils/common.py
@@ -43,7 +43,8 @@ class chi_image_type(object):
 class chi_image(object):
     uuid = None
     name = None
-    build_date = None
+    revision = None
+    build_timestamp = None
     size_bytes = None
     checksum_md5 = None
 
@@ -51,15 +52,21 @@ class chi_image(object):
         self,
         image_type: chi_image_type,
         uuid,
-        build_date,
+        revision,
+        build_timestamp,
         size_bytes,
         checksum_md5,
     ) -> None:
         self.image_type = image_type
         self.uuid = uuid
-        self.build_date = build_date
+        self.revision = revision
+        self.build_timestamp = build_timestamp
         self.size_bytes = size_bytes
         self.checksum_md5 = checksum_md5
 
     def archival_name(self) -> str:
-        return "{}-{}".format(self.image_type.production_name(), self.build_date)
+        return "{}-{}-{}".format(
+            self.image_type.production_name(),
+            self.revision,
+            self.build_timestamp,
+        )

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,93 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+OBJECT_STORE_URL = "https://chi.tacc.chameleoncloud.org:7480/swift/v1"
+CENRTALIZED_CONTAINER_ACCOUNT = "AUTH_570aad8999f7499db99eae22fe9b29bb"
+CENTRALIZED_CONTAINER_NAME = "chameleon-images"
+CENTRALIZED_CONTAINER_URL = (
+    f"{OBJECT_STORE_URL}/{CENRTALIZED_CONTAINER_ACCOUNT}/{CENTRALIZED_CONTAINER_NAME}"
+)
+
+
+class chi_image_type(object):
+    distro_family = None
+    distro_release = None
+    image_variant = None
+
+    def __init__(self, family, release, variant) -> None:
+        self.distro_family = family
+        self.distro_release = release
+        self.image_variant = variant
+
+    def __eq__(self, other: object) -> bool:
+        """Compare 3 class variables to check equality"""
+        return (self.distro_family, self.distro_release, self.image_variant) == (
+            getattr(other, "distro_family", None),
+            getattr(other, "distro_release", None),
+            getattr(other, "image_variant", None),
+        )
+
+
+class chi_image(chi_image_type):
+    uuid = None
+    name = None
+    build_date = None
+    size_bytes = None
+    checksum_md5 = None
+
+    def gen_canonical_name(self, family, release, variant=None, build_date=None) -> str:
+        valid_tags = [t for t in [family, release, variant, build_date] if t]
+        image_name = "-".join(valid_tags)
+        if image_name:
+            return image_name
+        else:
+            raise ValueError("Could not generate canonical name")
+
+    def __init__(
+        self, family, release, variant, uuid, name, build_date, size_bytes, checksum_md5
+    ) -> None:
+        self.uuid = uuid
+        self.build_date = build_date
+        self.size_bytes = size_bytes
+        self.checksum_md5 = checksum_md5
+
+        self.name = name
+
+        super().__init__(family, release, variant)
+
+
+class ChameleonImage(object):
+    build_distro = None
+    build_os_base_image_revision = None
+    build_release = None
+    build_repo = None
+    build_tag = None
+
+
+def archival_name(prod_image_name, image):
+    return "{}-{}-{}".format(
+        prod_image_name,
+        image["build-os-base-image-revision"],
+        image["build-timestamp"],
+    )
+
+
+def list_supportedimages(conn):
+    """
+    Fetch a list of all supported images from glance.
+    To be "supported", they must satisfy:
+    - owned by openstack project
+    - public
+    - name matches schema from image_builder
+    - attached metadata == ???
+    """
+    images = conn.list_images()
+    return images
+
+
+def remove_prefix(str, prefix):
+    if str.startswith(prefix):
+        return str[len(prefix) :]
+    else:
+        return str

--- a/utils/common.py
+++ b/utils/common.py
@@ -34,6 +34,15 @@ class chi_image_type(object):
             getattr(other, "image_variant", None),
         )
 
+    def __hash__(self) -> int:
+        # production name, and it's components, are configurable, and don't uniquely
+        # identify a "supported image". instead, use tuple of family, release, variant
+        identifier = (self.distro_family, self.distro_release, self.image_variant)
+        return hash(identifier)
+
+    def __repr__(self) -> str:
+        return self.production_name()
+
     def production_name(self):
         if self.production_name_suffix:
             return f"{self.production_name_base}-{self.production_name_suffix}"
@@ -81,7 +90,7 @@ def load_supported_images_from_config(config_file_path):
     supported_distros_dict = config.get("supported_distros")
     supported_variants_dict = config.get("supported_variants")
 
-    supported_images = []
+    supported_images = set()
 
     for distro_name, distro_values in supported_distros_dict.items():
         for release_name, release_values in distro_values.get("releases").items():
@@ -99,5 +108,6 @@ def load_supported_images_from_config(config_file_path):
                 except ValueError:
                     continue
                 else:
-                    supported_images.append(image)
+                    supported_images.add(image)
+
     return supported_images

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,4 +1,5 @@
 import logging
+import yaml
 
 LOG = logging.getLogger(__name__)
 
@@ -70,3 +71,33 @@ class chi_image(object):
             self.revision,
             self.build_timestamp,
         )
+
+
+def load_supported_images_from_config(config_file_path):
+    config = {}
+    with open(config_file_path, "r") as fp:
+        config = yaml.safe_load(fp)
+
+    supported_distros_dict = config.get("supported_distros")
+    supported_variants_dict = config.get("supported_variants")
+
+    supported_images = []
+
+    for distro_name, distro_values in supported_distros_dict.items():
+        for release_name, release_values in distro_values.get("releases").items():
+            for variant_name in release_values.get("variants", []):
+                variant_details = supported_variants_dict.get(variant_name)
+
+                try:
+                    image = chi_image_type(
+                        family=distro_name,
+                        release=release_name,
+                        variant=variant_name,
+                        prod_name=release_values.get("prod_name"),
+                        suffix=variant_details.get("prod_name_suffix"),
+                    )
+                except ValueError:
+                    continue
+                else:
+                    supported_images.append(image)
+    return supported_images

--- a/utils/common.py
+++ b/utils/common.py
@@ -26,6 +26,9 @@ class chi_image_type(object):
         self.production_name_base = prod_name
         self.production_name_suffix = suffix
 
+        if not family or not release or not variant:
+            raise ValueError("Supplied image type missing required identifier")
+
     def __eq__(self, other: object) -> bool:
         """Compare 3 class variables to check equality"""
         return (self.distro_family, self.distro_release, self.image_variant) == (
@@ -74,12 +77,22 @@ class chi_image(object):
         self.size_bytes = size_bytes
         self.checksum_md5 = checksum_md5
 
+        if not uuid or not revision or not build_timestamp:
+            raise ValueError("Supplied image missing required identifier")
+
     def archival_name(self) -> str:
         return "{}-{}-{}".format(
             self.image_type.production_name(),
             self.revision,
             self.build_timestamp,
         )
+
+    def __hash__(self) -> int:
+        identifier = (self.image_type, self.revision, self.build_timestamp)
+        return hash(identifier)
+
+    def __repr__(self) -> str:
+        return self.archival_name()
 
 
 def load_supported_images_from_config(config_file_path):

--- a/utils/common.py
+++ b/utils/common.py
@@ -61,6 +61,16 @@ class chi_image(object):
     size_bytes = None
     checksum_md5 = None
 
+    def _identifier(self):
+        """Define tuple to use for hashing and comparison"""
+        return (
+            self.image_type.distro_family,
+            self.image_type.distro_release,
+            self.image_type.image_variant,
+            self.revision,
+            self.build_timestamp,
+        )
+
     def __init__(
         self,
         image_type: chi_image_type,
@@ -87,10 +97,17 @@ class chi_image(object):
             self.build_timestamp,
         )
 
+    # To use a class in Set comparisons, both __hash__ and __eq__ must be defined.
+    # If __eq__ returns true for two objects, __hash__ must return the same value for both.
     def __hash__(self) -> int:
-        identifier = (self.image_type, self.revision, self.build_timestamp)
-        return hash(identifier)
+        return hash(self._identifier())
 
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, chi_image) and self._identifier() == other._identifier()
+        )
+
+    # Define __repr__ to make logs and debugging more human readable
     def __repr__(self) -> str:
         return self.archival_name()
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+
+OBJECT_STORE_URL = "https://chi.tacc.chameleoncloud.org:7480/swift/v1"
+CENRTALIZED_CONTAINER_ACCOUNT = "AUTH_570aad8999f7499db99eae22fe9b29bb"
+CENTRALIZED_CONTAINER_NAME = "chameleon-images"
+CENTRALIZED_CONTAINER_URL = (
+    f"{OBJECT_STORE_URL}/{CENRTALIZED_CONTAINER_ACCOUNT}/{CENTRALIZED_CONTAINER_NAME}"
+)
+SWIFT_META_HEADER_PREFIX = "x-object-meta-"
+
+ImageField = namedtuple("ImageField", ("chi", "glance", "swift"))
+
+# used with getattr
+IMAGE_TYPE_MAPPINGS = {
+    ImageField("distro_family", "build-distro", "x-object-meta-build-distro"),
+    ImageField("distro_release", "build-release", "x-object-meta-build-release"),
+    ImageField("image_variant", "build-variant", "x-object-meta-build-variant"),
+}
+
+IMAGE_INSTANCE_MAPPINGS = {
+    ImageField(
+        "base_image_revision",
+        "build-os-base-image-revision",
+        "x-object-meta-build-os-base-image-revision",
+    ),
+    ImageField("build_timestamp", "build-timestamp", "x-object-meta-build-timestamp"),
+    ImageField("build_tag", "build-tag", "x-object-meta-build-tag"),
+    ImageField("build_repo", "build-repo", "x-object-meta-build-repo"),
+    ImageField(
+        "build_repo_commit", "build-repo-commit", "x-object-meta-build-repo-commit"
+    ),
+    ImageField("uuid", "id", None),
+    ImageField("size_bytes", "size", None),
+    ImageField("checksum_md5", "checksum", None),
+}
+
+
+def map_attribute_value(field: ImageField, s_type, s_obj, d_type, d_obj):
+    # programatically fetch key names from a namedtuple
+    # and map value between source and dest dictionary
+    source_attr_key = getattr(field, s_type)
+    dest_attr_key = getattr(field, d_type)
+
+    source_attr_value = getattr(s_obj, source_attr_key, None)
+    d_obj[dest_attr_key] = source_attr_value

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -29,17 +29,7 @@ IMAGE_INSTANCE_MAPPINGS = {
     ImageField(
         "build_repo_commit", "build-repo-commit", "x-object-meta-build-repo-commit"
     ),
-    ImageField("uuid", "id", None),
-    ImageField("size_bytes", "size", None),
-    ImageField("checksum_md5", "checksum", None),
+    ImageField("size_bytes", "size", "content-length"),
+    ImageField("uuid", "id", "uuid"),
+    ImageField("checksum_md5", "checksum", "checksum_md5"),
 }
-
-
-def map_attribute_value(field: ImageField, s_type, s_obj, d_type, d_obj):
-    # programatically fetch key names from a namedtuple
-    # and map value between source and dest dictionary
-    source_attr_key = getattr(field, s_type)
-    dest_attr_key = getattr(field, d_type)
-
-    source_attr_value = getattr(s_obj, source_attr_key, None)
-    d_obj[dest_attr_key] = source_attr_value

--- a/utils/glance.py
+++ b/utils/glance.py
@@ -1,0 +1,36 @@
+from utils import common
+import logging
+from openstack.image.v2.image import Image
+
+LOG = logging.getLogger(__name__)
+
+
+class chi_glance_image(common.chi_image):
+    """Define methods to map between glance images and canonical representation"""
+
+    def __init__(self, image: Image) -> None:
+        uuid = image.id
+        size_bytes = image.size
+        checksum_md5 = image.checksum
+
+        properties = image.properties
+        revision = properties.get("build-os-base-image-revision")
+        build_timestamp = properties.get("build-timestamp")
+
+        distro_family = properties.get("build-distro")
+        distro_release = properties.get("build-release")
+        image_variant = properties.get("build-variant")
+
+        # TODO: load base image name and suffix from config file
+        image_type = common.chi_image_type(
+            distro_family, distro_release, image_variant, None, None
+        )
+
+        super().__init__(
+            image_type,
+            uuid,
+            revision,
+            build_timestamp,
+            size_bytes,
+            checksum_md5,
+        )

--- a/utils/glance.py
+++ b/utils/glance.py
@@ -4,44 +4,19 @@ import logging
 from openstack.image.v2.image import Image
 from glanceclient.client import Client as glanceClient
 from keystoneauth1.session import Session as ksSession
+from glanceclient.v2.client import Client as v2Client
+import openstack
+from openstack.connection import Connection
+from openstack import exceptions
+from glanceclient.exc import HTTPNotFound
 
 LOG = logging.getLogger(__name__)
-
-
-def filter_glance_images(session: ksSession, filters={}):
-    client = glanceClient(version=2, session=session)
-    image_client = client.images
-
-    # query_params = {
-    #     "visibility": "public",
-    #     "name": "something",
-    #     "owner": "something",
-    #     "status": "something",
-    #     "tag": "something",
-    # }
-
-    # TODO we can't filter based on these, as they are not 'tags'
-    # query_params = {
-    #     "build-distro": "ubuntu",
-    #     "build-release": "focal",
-    #     "build-variant": "base",
-    # }
-
-    images_generator = image_client.list(**filters)
-
-    for glance_img in images_generator:
-        try:
-            glance_img = chi_glance_image(glance_img)
-        except ValueError as e:
-            LOG.debug(f"Skipping glance image: {e}")
-        else:
-            yield glance_img
 
 
 class chi_glance_image(common.chi_image):
     """Define methods to map between glance images and canonical representation"""
 
-    def __init__(self, image: Image) -> None:
+    def __init__(self, image: Image, supported_images=[]) -> None:
         uuid = image.id
         size_bytes = image.size
         checksum_md5 = image.checksum
@@ -49,19 +24,130 @@ class chi_glance_image(common.chi_image):
         build_timestamp = image.get("build-timestamp")
 
         # TODO: load base image name and suffix from config file
-        image_type = common.chi_image_type(
+        config_type = common.chi_image_type(
             image.get("build-distro"),
             image.get("build-release"),
             image.get("build-variant"),
             None,
             None,
         )
+        if supported_images:
+            try:
+                config_type = [i for i in supported_images if config_type == i][0]
+            except IndexError:
+                LOG.warn("could not load name from config")
 
         super().__init__(
-            image_type,
+            config_type,
             uuid,
             revision,
             build_timestamp,
             size_bytes,
             checksum_md5,
         )
+
+
+class glance_manager(object):
+    session: ksSession = None
+    client: v2Client = None
+    conn: Connection = None
+
+    supported_images = None
+
+    def __init__(self, session: ksSession = None, supported_images=None) -> None:
+        if session:
+            self.session = session
+        else:
+            connection = openstack.connect()
+            self.session = connection.session
+            self.client = glanceClient(version=2, session=self.session)
+            self.conn = connection
+
+        if supported_images:
+            self.supported_images = supported_images
+
+    def filter_glance_images(self, filters={}):
+        # query_params = {
+        #     "visibility": "public",
+        #     "name": "something",
+        #     "owner": "something",
+        #     "status": "something",
+        #     "tag": "something",
+        # }
+
+        # TODO we can't filter based on these, as they are not 'tags'
+        # query_params = {
+        #     "build-distro": "ubuntu",
+        #     "build-release": "focal",
+        #     "build-variant": "base",
+        # }
+
+        images_generator = self.client.images.list(**filters)
+
+        for glance_img in images_generator:
+            try:
+                glance_img = chi_glance_image(
+                    glance_img, supported_images=self.supported_images
+                )
+            except ValueError as e:
+                LOG.debug(f"Skipping glance image: {e}")
+            else:
+                yield glance_img
+
+    def sync_image_to_glance(self, image: chi_glance_image):
+        """This method takes an image with a publicly visible url in swift,
+        and commands glance to download it."""
+
+        new_image_uuid = image.uuid
+        new_image_archival_name = image.archival_name()
+        new_image_production_name = image.image_type.production_name()
+
+        # Check if exact image already uploaded
+        try:
+            glance_image_by_uuid = self.client.images.get(image_id=new_image_uuid)
+        except HTTPNotFound:
+            pass
+        else:
+            if glance_image_by_uuid:
+                LOG.warning(f"Not syncing {image}, UUID is already present")
+                return
+
+        # Check if image already uploaded and archived
+        try:
+            filters = {"name": new_image_archival_name}
+            glance_image_by_archival_name = list(
+                self.client.images.list(filters=filters)
+            )
+        except HTTPNotFound:
+            pass
+        else:
+            if glance_image_by_archival_name:
+                LOG.warning(f"Not syncing {image}, already archived on target")
+                return
+
+        # Check if exact image already uploaded and production
+        try:
+            filters = {"name": new_image_production_name}
+            glance_image_by_production_name = list(
+                self.client.images.list(filters=filters)
+            )
+        except HTTPNotFound:
+            pass
+        else:
+            if len(glance_image_by_production_name) == 1:
+                current_production_image = chi_glance_image(
+                    glance_image_by_production_name[0]
+                )
+                if (
+                    image.build_timestamp == current_production_image.build_timestamp
+                ) and (image.revision == current_production_image.revision):
+                    LOG.warning(f"Not syncing {image}, already uploaded as production")
+                    return
+            elif len(glance_image_by_production_name) > 1:
+                LOG.warning(
+                    f"Not syncing, Duplicates found for production image {image}"
+                )
+                return
+
+        # checks passed, upload image with archival name to avoid conflicts
+        LOG.warning(f"uploading archival image: {image}")

--- a/utils/glance.py
+++ b/utils/glance.py
@@ -10,12 +10,12 @@ from openstack.connection import Connection
 from openstack import exceptions
 from glanceclient.exc import HTTPNotFound, HTTPConflict
 
-from utils.swift import swift_image
+from utils.swift import chi_image_swift
 from utils.constants import (
     IMAGE_TYPE_MAPPINGS,
     IMAGE_INSTANCE_MAPPINGS,
-    map_attribute_value,
 )
+from utils.common import map_attribute_value
 
 LOG = logging.getLogger(__name__)
 
@@ -75,21 +75,6 @@ class glance_manager(object):
         return glance_image
 
     def filter_glance_images(self, filters={}):
-        # query_params = {
-        #     "visibility": "public",
-        #     "name": "something",
-        #     "owner": "something",
-        #     "status": "something",
-        #     "tag": "something",
-        # }
-
-        # TODO we can't filter based on these, as they are not 'tags'
-        # query_params = {
-        #     "build-distro": "ubuntu",
-        #     "build-release": "focal",
-        #     "build-variant": "base",
-        # }
-
         images_generator = self.client.images.list(**filters)
 
         for glance_img in images_generator:
@@ -100,7 +85,7 @@ class glance_manager(object):
             else:
                 yield chi_image
 
-    def import_image_from_swift(self, image: swift_image):
+    def import_image_from_swift(self, image: chi_image_swift):
         # Build the image attributes
         new_image_id = str(image.uuid)
 
@@ -141,7 +126,7 @@ class glance_manager(object):
                 f"image {glance_image_id} not queued, may have been uploaded in a different thread"
             )
 
-    def sync_image_to_glance(self, image: swift_image):
+    def sync_image_to_glance(self, image: chi_image_swift):
         """This method takes an image with a publicly visible url in swift,
         and commands glance to download it."""
 

--- a/utils/glance.py
+++ b/utils/glance.py
@@ -1,8 +1,41 @@
 from utils import common
 import logging
+
 from openstack.image.v2.image import Image
+from glanceclient.client import Client as glanceClient
+from keystoneauth1.session import Session as ksSession
 
 LOG = logging.getLogger(__name__)
+
+
+def filter_glance_images(session: ksSession, filters={}):
+    client = glanceClient(version=2, session=session)
+    image_client = client.images
+
+    # query_params = {
+    #     "visibility": "public",
+    #     "name": "something",
+    #     "owner": "something",
+    #     "status": "something",
+    #     "tag": "something",
+    # }
+
+    # TODO we can't filter based on these, as they are not 'tags'
+    # query_params = {
+    #     "build-distro": "ubuntu",
+    #     "build-release": "focal",
+    #     "build-variant": "base",
+    # }
+
+    images_generator = image_client.list(**filters)
+
+    for glance_img in images_generator:
+        try:
+            glance_img = chi_glance_image(glance_img)
+        except ValueError as e:
+            LOG.debug(f"Skipping glance image: {e}")
+        else:
+            yield glance_img
 
 
 class chi_glance_image(common.chi_image):
@@ -12,18 +45,16 @@ class chi_glance_image(common.chi_image):
         uuid = image.id
         size_bytes = image.size
         checksum_md5 = image.checksum
-
-        properties = image.properties
-        revision = properties.get("build-os-base-image-revision")
-        build_timestamp = properties.get("build-timestamp")
-
-        distro_family = properties.get("build-distro")
-        distro_release = properties.get("build-release")
-        image_variant = properties.get("build-variant")
+        revision = image.get("build-os-base-image-revision")
+        build_timestamp = image.get("build-timestamp")
 
         # TODO: load base image name and suffix from config file
         image_type = common.chi_image_type(
-            distro_family, distro_release, image_variant, None, None
+            image.get("build-distro"),
+            image.get("build-release"),
+            image.get("build-variant"),
+            None,
+            None,
         )
 
         super().__init__(

--- a/utils/swift.py
+++ b/utils/swift.py
@@ -96,6 +96,6 @@ class swift_manager(object):
                 try:
                     swift_image_detail = self._get_image_detail(s, list_item)
                 except ValueError as e:
-                    LOG.warning(f"Image doesn't match schema, {e}")
+                    LOG.debug(f"Skipping swift image: {e}")
                 else:
                     yield swift_image_detail

--- a/utils/swift.py
+++ b/utils/swift.py
@@ -32,7 +32,8 @@ class swift_image(common.chi_image):
         release = header_dict.get("x-object-meta-build-release")
         variant = header_dict.get("x-object-meta-build-variant")
         size_bytes = header_dict.get("content-length")
-        build_date = header_dict.get("x-object-meta-build-timestamp")
+        build_revision = header_dict.get("x-object-meta-build-os-base-image-revision")
+        build_timestamp = header_dict.get("x-object-meta-build-timestamp")
 
         checksum_md5 = list_item.hash
         uuid = list_item.uuid
@@ -40,7 +41,9 @@ class swift_image(common.chi_image):
         # TODO Load production name and suffix from config file
         img_type = common.chi_image_type(family, release, variant, None, None)
 
-        super().__init__(img_type, uuid, build_date, size_bytes, checksum_md5)
+        super().__init__(
+            img_type, uuid, build_revision, build_timestamp, size_bytes, checksum_md5
+        )
 
 
 class swift_manager(object):

--- a/utils/swift.py
+++ b/utils/swift.py
@@ -37,11 +37,10 @@ class swift_image(common.chi_image):
         checksum_md5 = list_item.hash
         uuid = list_item.uuid
 
-        name = self.gen_canonical_name(family, release, variant, build_date)
+        # TODO Load production name and suffix from config file
+        img_type = common.chi_image_type(family, release, variant, None, None)
 
-        super().__init__(
-            family, release, variant, uuid, name, build_date, size_bytes, checksum_md5
-        )
+        super().__init__(img_type, uuid, build_date, size_bytes, checksum_md5)
 
 
 class swift_manager(object):
@@ -70,7 +69,6 @@ class swift_manager(object):
             response = s.get(url=self.swift_endpoint_url, headers=self.swift_headers)
             data = response.json()
             for item in data:
-
                 # Ensure list item is valid, and not a chunk
                 try:
                     list_item = swift_list_item(item)

--- a/utils/swift.py
+++ b/utils/swift.py
@@ -1,0 +1,86 @@
+from collections.abc import Mapping, Generator
+from utils import common
+import uuid
+import requests
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class swift_list_item(object):
+    chunk_name = None
+    hash = None
+    bytes = None
+    last_modified = None
+    uuid = None
+
+    def __init__(self, header_dict: Mapping) -> None:
+        self.chunk_name = header_dict.get("name")
+        self.hash = header_dict.get("hash")
+        self.bytes = header_dict.get("bytes")
+        self.last_modified = header_dict.get("last_modified")
+        self.uuid = uuid.UUID(hex=self.chunk_name)
+
+
+class swift_image(common.chi_image):
+    def __init__(self, list_item: swift_list_item, header_dict) -> None:
+        """The necessary info is split between the directory listing,
+        and the per-item head request."""
+
+        family = header_dict.get("x-object-meta-build-distro")
+        release = header_dict.get("x-object-meta-build-release")
+        variant = header_dict.get("x-object-meta-build-variant")
+        size_bytes = header_dict.get("content-length")
+        build_date = header_dict.get("x-object-meta-build-timestamp")
+
+        checksum_md5 = list_item.hash
+        uuid = list_item.uuid
+
+        name = self.gen_canonical_name(family, release, variant, build_date)
+
+        super().__init__(
+            family, release, variant, uuid, name, build_date, size_bytes, checksum_md5
+        )
+
+
+class swift_manager(object):
+    swift_endpoint_url = common.CENTRALIZED_CONTAINER_URL
+    swift_headers = {"Accept": "application/json"}
+
+    def __init__(self, swift_endpoint_url=None, swift_headers=None) -> None:
+        if swift_endpoint_url:
+            self.swift_endpoint_url = swift_endpoint_url
+
+        if swift_headers:
+            self.swift_headers = swift_headers
+
+    def _get_image_detail(
+        self, session: requests.Session, s_item: swift_list_item
+    ) -> swift_image:
+        image_uuid = s_item.uuid
+        image_url = f"{self.swift_endpoint_url}/{image_uuid}"
+        response = session.head(url=image_url, headers=self.swift_headers)
+
+        new_swift_image = swift_image(s_item, response.headers)
+        return new_swift_image
+
+    def list_images(self) -> Generator[swift_image, None, None]:
+        with requests.Session() as s:
+            response = s.get(url=self.swift_endpoint_url, headers=self.swift_headers)
+            data = response.json()
+            for item in data:
+
+                # Ensure list item is valid, and not a chunk
+                try:
+                    list_item = swift_list_item(item)
+                except ValueError:
+                    continue
+
+                # Ensure only images with matching metadata are returned
+                try:
+                    swift_image_detail = self._get_image_detail(s, list_item)
+                except ValueError as e:
+                    LOG.warning(f"Image doesn't match schema, {e}")
+                else:
+                    yield swift_image_detail

--- a/utils/swift.py
+++ b/utils/swift.py
@@ -40,12 +40,12 @@ class swift_image(common.chi_image):
         checksum_md5 = list_item.hash
         uuid = list_item.uuid
 
-        tmp_type = common.chi_image_type(family, release, variant, None, None)
-        try:
-            config_type = [i for i in supported_images if tmp_type == i][0]
-        except IndexError:
-            config_type = tmp_type
-            LOG.warn("could not load name from config")
+        config_type = common.chi_image_type(family, release, variant, None, None)
+        if supported_images:
+            try:
+                config_type = [i for i in supported_images if config_type == i][0]
+            except IndexError:
+                LOG.warn("could not load name from config")
 
         super().__init__(
             config_type, uuid, build_revision, build_timestamp, size_bytes, checksum_md5


### PR DESCRIPTION
This PR establishes a framework for refactoring the image upload/download tools.

We define a "schema" for the "supported image", where it must have:
- arch (amd64/arm64)
- base_distribution (ubuntu/centos)
- distribution_release (20.04/stream8/...)
- image_variant (base, cuda, fpga, etc...)

An instance of a supported image will additionally have:
- build stamp
- name
- uuid


The main functions are to be able to convert each of the following to either the "supported_image" or "supported_image_instance"
- yaml config file
- list of images in swift
- list of images in glance


The desired behavior of the image distribution tool is then:

- get list of supported images from config file
- get list of available images from swift
- get list of published images from glance

Images to upload are then: (config union swift) - glance
Missing images to warn about are: (config - swift)