### PR TITLE
use gha to build image-tools container

### DIFF
--- a/.github/workflows/site_tools.yml
+++ b/.github/workflows/site_tools.yml
@@ -1,0 +1,43 @@
+name: build image tools container
+
+on:
+  push:
+    branches:
+      - "master"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/chameleoncloud/chameleon_image_tools
+          tags: |
+            type=sha
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/site_tools.yml
+++ b/.github/workflows/site_tools.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           images: ghcr.io/chameleoncloud/chameleon_image_tools
           tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
             type=sha
 
       - name: Login to GitHub Container Registry
@@ -38,6 +41,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
create draft PR to exercise action

the current behavior (up for debate :) ) is to:

build the container on pushes to master, pushing new tags, or pull requests against master.
but only push the container on pushes to master or new tags.

the docker tags will be of the form:

https://github.com/docker/metadata-action?tab=readme-ov-file#typeref
Event | Ref | Output
-- | -- | --
pull_request | refs/pull/2/merge | pr-2
push | refs/heads/master | master
push | refs/heads/my/branch | my-branch
push tag | refs/tags/v1.2.3 | v1.2.3
push tag | refs/tags/v2.0.8-beta.67 | v2.0.8-beta.67

and https://github.com/docker/metadata-action?tab=readme-ov-file#typesha
with a tag like `sha-860c190`

Currently, sites are pulling the `latest` tag,  and we'll want to verify that the container still works before pushing that one.